### PR TITLE
Allow init with WKWebViewConfiguration

### DIFF
--- a/AFWebViewController/AFModalWebViewController.h
+++ b/AFWebViewController/AFModalWebViewController.h
@@ -7,6 +7,7 @@
 //
 
 @import UIKit;
+@class WKWebViewConfiguration;
 
 @interface AFModalWebViewController : UINavigationController
 
@@ -73,6 +74,16 @@
  *  @return Instance of `AFModalWebViewController`.
  */
 - (instancetype)initWithURLRequest:(NSURLRequest *)request;
+
+/**
+ *  Instantiate a modal WebViewController with URL request.
+ *
+ *  @param request        NSURLRequest to show in web view.
+ *  @param configuration  a collection of properties used to initialize a web view.
+ *
+ *  @return Instance of `AFModalWebViewController`.
+ */
+- (instancetype)initWithURLRequest:(NSURLRequest *)request configuration:(WKWebViewConfiguration *)configuration;
 
 /**
  *  Instantiate a modal WebViewController with HTML string and base URL.

--- a/AFWebViewController/AFModalWebViewController.m
+++ b/AFWebViewController/AFModalWebViewController.m
@@ -48,7 +48,13 @@
 }
 
 - (instancetype)initWithURLRequest:(NSURLRequest *)request {
-    self.webViewController = [[AFWebViewController alloc] initWithURLRequest:request];
+    return [self initWithURLRequest:request configuration:nil];
+}
+
+- (instancetype)initWithURLRequest:(NSURLRequest *)request
+                     configuration:(WKWebViewConfiguration *)configuration
+{
+    self.webViewController = [[AFWebViewController alloc] initWithURLRequest:request configuration:configuration];
     if (self = [super initWithRootViewController:self.webViewController]) {
         UIBarButtonItem *doneButton = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone target:self.webViewController action:@selector(doneButtonTapped:)];
         

--- a/AFWebViewController/AFWebViewController.h
+++ b/AFWebViewController/AFWebViewController.h
@@ -8,6 +8,9 @@
 
 @import UIKit;
 @class WKWebView;
+@class WKWebViewConfiguration;
+
+NS_ASSUME_NONNULL_BEGIN
 
 @interface AFWebViewController : UIViewController
 
@@ -75,7 +78,17 @@
  *
  *  @return Instance of `AFWebViewController`.
  */
-- (instancetype)initWithURLRequest:(NSURLRequest *)request NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithURLRequest:(NSURLRequest *)request;
+
+/**
+ *  Instantiate WebViewController with URL request.
+ *
+ *  @param request        NSURLRequest to show in web view.
+ *  @param configuration  a collection of properties used to initialize a web view.
+ *
+ *  @return Instance of `AFWebViewController`.
+ */
+- (instancetype)initWithURLRequest:(NSURLRequest *)request configuration:(nullable WKWebViewConfiguration *)configuration NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Instantiate WebViewController with HTML string and base URL.
@@ -94,3 +107,6 @@
 @property (nonatomic, strong) UIColor *toolbarTintColor;
 
 @end
+
+NS_ASSUME_NONNULL_END
+

--- a/AFWebViewController/AFWebViewController.m
+++ b/AFWebViewController/AFWebViewController.m
@@ -17,6 +17,7 @@
 // Bar buttons
 @property (nonatomic, strong) UIBarButtonItem *backBarButtonItem, *forwardBarButtonItem, *refreshBarButtonItem, *stopBarButtonItem, *actionBarButtonItem;
 @property (nonatomic, strong) NSURLRequest *request;
+@property (nonatomic, strong, nullable) WKWebViewConfiguration *configuration;
 @property (nonatomic, strong) UIProgressView *progressView;
 @end
 
@@ -51,15 +52,22 @@
 }
 
 - (instancetype)initWithURLRequest:(NSURLRequest *)request {
-    if (self = [super init]) {
+    return [self initWithURLRequest:request configuration:nil];
+}
+
+- (instancetype)initWithURLRequest:(NSURLRequest *)request
+                     configuration:(nullable WKWebViewConfiguration *)configuration
+{
+    if (self = [super initWithNibName:nil bundle:nil]) {
         self.request = request;
+        self.configuration = configuration;
     }
     return self;
 }
 
 - (instancetype)initWithHTMLString:(NSString *)HTMLString andBaseURL:(NSURL *)baseURL {
     
-    if (self = [super init]) {
+    if (self = [super initWithNibName:nil bundle:nil]) {
         [self.webView loadHTMLString:HTMLString baseURL:baseURL];
     }
     return self;
@@ -135,7 +143,11 @@
 
 - (WKWebView *)webView {
     if (!_webView) {
-        _webView = [[WKWebView alloc] initWithFrame:[UIScreen mainScreen].bounds];
+        if (_configuration) {
+            _webView = [[WKWebView alloc] initWithFrame:[UIScreen mainScreen].bounds configuration:_configuration];
+        } else {
+            _webView = [[WKWebView alloc] initWithFrame:[UIScreen mainScreen].bounds];
+        }
         _webView.navigationDelegate = self;
     }
     return _webView;


### PR DESCRIPTION
We have been using your library like this for a long time, thinking it should be a good idea to push it back. 

This allow user of the library supply a `WKWebViewConfiguration` when initializing **AFModalWebViewController.h** 

I notice that calling `[super init]` will have a warning, replace that with `[super initWithNibName:nil bundle:nil]` too.