### PR TITLE
fix back button for subclassed AFWebViewController

### DIFF
--- a/AFWebViewController/AFWebViewController.m
+++ b/AFWebViewController/AFWebViewController.m
@@ -154,7 +154,7 @@
 }
 
 - (UIImage *)frameworkBundleImage:(NSString *)imageName {
-    NSBundle *frameworkBundle = [NSBundle bundleForClass:[self class]];
+    NSBundle *frameworkBundle = [NSBundle bundleForClass: NSClassFromString(@"AFWebViewController")];
     return [UIImage imageNamed:imageName inBundle:frameworkBundle compatibleWithTraitCollection:nil];
 }
 


### PR DESCRIPTION
- (UIImage *)frameworkBundleImage:(NSString *)imageName
looks up the back and forward button images in a non-existent bundle when AFWebViewController is subclassed.